### PR TITLE
Updated dependencies of GUI App Service 

### DIFF
--- a/code_examples/Python/app_generic_gui/Dockerfile
+++ b/code_examples/Python/app_generic_gui/Dockerfile
@@ -1,8 +1,8 @@
-FROM tiangolo/uwsgi-nginx:python2.7-alpine3.7
+FROM tiangolo/uwsgi-nginx:python3.6-alpine3.7
 
 # Install dependencies
 COPY requirements.txt /tmp
-RUN apk add --update --virtual build-dep make gcc musl-dev python-dev libxml2-dev linux-headers libxslt-dev \
+RUN apk add --update --virtual build-dep make gcc musl-dev python3-dev libxml2-dev linux-headers libxslt-dev \
   && pip install -r /tmp/requirements.txt \
   && rm /tmp/requirements.txt \
   && apk del build-dep \

--- a/code_examples/Python/app_generic_gui/PythonTools/readFromXls.py
+++ b/code_examples/Python/app_generic_gui/PythonTools/readFromXls.py
@@ -23,9 +23,6 @@ from collections import OrderedDict
 import simplejson as json
 import sys
 
-reload(sys)
-sys.setdefaultencoding('utf-8')
-
 
 def xls2JSON(filename):
     # Open the workbook

--- a/code_examples/Python/app_generic_gui/app/GUIAppService.py
+++ b/code_examples/Python/app_generic_gui/app/GUIAppService.py
@@ -65,7 +65,6 @@ class GUIAppService(ServiceBase):
         logging.info('Validating request...')
 
         if sh.validateSession(token=sessionToken, wsdlurl=authURL):
-
             logging.info('Request is valid')
 
             logging.info('Reading web page header')
@@ -83,8 +82,7 @@ class GUIAppService(ServiceBase):
 
             outputPage = readPageHeader + readPageData + addServiceID + addSessionToken + addWFMURL + readPageFooter
 
-            outputs = [base64.b64encode(outputPage)] + guiSrvc.standard_vals_list
-
+            outputs = [base64.b64encode(outputPage.encode(encoding='utf-8', errors='strict'))] + guiSrvc.standard_vals_list
             logging.info('Returning web page with standard values')
 
             return tuple(outputs)

--- a/code_examples/Python/app_generic_gui/requirements.txt
+++ b/code_examples/Python/app_generic_gui/requirements.txt
@@ -6,7 +6,7 @@ profilehooks==1.10.0
 simplejson==3.16.0
 spyne==2.12.14
 suds_jurko==0.6
-Werkzeug==0.14.1
+Werkzeug==0.15.3
 xlrd==1.1.0
 xmltodict==0.11.0
 lxml==4.2.5


### PR DESCRIPTION
- Now using Python 3.6 as 2.X reached EOL
- Upgraded Werkzeug to 15.X.X. as previous version had critical security issues
- Adjustments of code for new python version with encoding message and sys imports.